### PR TITLE
Trivial: rm stray whitespace character.

### DIFF
--- a/how-we-work.md
+++ b/how-we-work.md
@@ -46,7 +46,7 @@ It’s far better for everyone’s concentration and sanity if you collaborate a
 
 Don’t take that as gospel, though. Some times you really DO need to tightly collaborate with someone for an extended period of time, and that’s fine. We have pings, hangouts, screensharing, or even in-person collaboration for when nothing else will do. (But most of the time something else will).
 
-All that being said, you should still ensure that there is ample  overlap with the people you work with most of the time. While most roadblocks can just as well be cleared in 15-30-60 minutes, they become real annoying if it’s a one-day turn-around every time.
+All that being said, you should still ensure that there is ample overlap with the people you work with most of the time. While most roadblocks can just as well be cleared in 15-30-60 minutes, they become real annoying if it’s a one-day turn-around every time.
 
 In certain departments, like Support and Ops, it’s even more important that people are dependently available when they say they will be. That work has a lot of interrupt-based jobs that simply needs to be done right here, right now. So what applies to almost all work for design and programming and QA may well apply a little less frequently there.
 


### PR DESCRIPTION
`"ample  overlap"` (2 spaces) -->
`"ample overlap"` (1 space) .