### PR TITLE
Add link for Designer titles in "Making a Career" page.

### DIFF
--- a/making-a-career.md
+++ b/making-a-career.md
@@ -19,7 +19,7 @@ But these titles make it clear to everyone where someone is in their career prog
 
 Day to day, though, these titles aren't really much of a factor. It's not like they're printed on your HELLO MY NAME IS sticker at the meetups (not that we have those anyway!). But they do give newcomers another way of orienting themselves at the company and it gives everyone a clear way of tracking their personal career progression at Basecamp.
 
-You can see the specific titles and profiencies expected for: [Programmers](https://github.com/basecamp/handbook/blob/master/titles-for-programmers.md).
+You can see the specific titles and profiencies expected for: [Programmers](https://github.com/basecamp/handbook/blob/master/titles-for-programmers.md), [Designers](https://github.com/basecamp/handbook/blob/master/titles-for-designers.md).
 
 ## Pay & Promotions
 

--- a/making-a-career.md
+++ b/making-a-career.md
@@ -23,7 +23,7 @@ You can see the specific titles and profiencies expected for: [Programmers](http
 
 ## Pay & Promotions
 
-Basecamp pays at the top 5% for our industry at Chicago salary levels, regardless of where an employee lives. The comparison data is provided by a company called Radford that polls compensation data from all the major companies in our industry and plenty of our smaller peers as well. Because we don't pay bonuses, we match our base compensation to the base + bonus of our peer group.
+Basecamp pays at the top 5% for our industry at San Francisco salary levels, regardless of where an employee lives. The comparison data is provided by a company called Radford that polls compensation data from all the major companies in our industry and plenty of our smaller peers as well. Because we don't pay bonuses, we match our base compensation to the base + bonus of our peer group.
 
 The Radford data is reviewed once per year at the end of November. If it's warranted, that is if the market rates in the top 5% have gone up, we'll increase pay on January 1st to follow suit. We don't decrease pay, even if the market rates may have dropped. If that happens, we'll hold them steady until they come up again.
 


### PR DESCRIPTION
Not sure if this is useful, but since I didn't see any page linking to Designer titles, I added one next to the "Programmers" link in the "Making a Career" page.