### PR TITLE
Remove expired job post link

### DIFF
--- a/orgchart.md
+++ b/orgchart.md
@@ -84,7 +84,7 @@ Before we ship a new feature, **Michael Berger** is our resident bug squasher. H
 
 ### Technical Operations
 
-The technical operations group is lead by **[TBD (we're hiring!)](https://basecamp.workable.com/jobs/1025288)** and consists of two teams:
+The technical operations group is lead by **[TBD]** and consists of two teams:
 
 #### Datacenter
 


### PR DESCRIPTION
Director of Operations job posting is expired, link doesn't work anymore.