### PR TITLE
fix typo and unify on "meetup" spelling

### DIFF
--- a/international-travel-guide.md
+++ b/international-travel-guide.md
@@ -22,7 +22,7 @@ Canadian passport holders don’t need a visa to enter the US for non-paid busin
 
 If your country does not participate in the Visa Waiver Program or you are not eligible for an ESTA, you’ll need to apply for a B-1 business visitor visa… the long way.
 
-We’ll work with you through this process. Start early, as soon as we have dates for a meetup or conference. Visa appointments and processing can take weeks to months. Ping Andrea as soon as you know that you’ll need a visa.
+We’ll work with you through this process. Start early, as soon as we have dates for a meet-up or conference. Visa appointments and processing can take weeks to months. Ping Andrea as soon as you know that you’ll need a visa.
 
 ### Trusted Traveler Programs
 

--- a/our-rituals.md
+++ b/our-rituals.md
@@ -14,7 +14,7 @@ It’s important to note that meetups can be overwhelming when we’re so used t
 
 Once a year, you can get together with a small group of your coworkers on a mini meetup at a destination of your choosing. Mini meetups should have a work focus. They’re not meant to be social trips, and you’re not doing just your day-to-day work in the same room as your coworkers. You should be collaborating on something meaningful. It certainly doesn’t have to be big and you don’t have to produce something by the end of the meetup. Pick something you’d love to have a week to discuss in person and have fun with it.
 
-Keep in mind: your mini-meetup team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meetup too. Limit yourself to 1 mini-meetup per year though, whether that’s with your dedicated team or with an offshoot team.
+Keep in mind: your mini meetup team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meet up too. Limit yourself to 1 mini meetup per year though, whether that’s with your dedicated team or with an offshoot team.
 
 Budget guidelines for mini meetups can be found [in Basecamp.](https://3.basecamp.com/2914079/buckets/34/messages/1400415368#__recording_1400437120)
 

--- a/our-rituals.md
+++ b/our-rituals.md
@@ -1,22 +1,22 @@
 # Our Rituals
 
-## Meetups
+## Meet-ups
 
-The entire company gathers in person twice a year. We meet up in a different city every time. In 2022, we traveled to Miami and Amsterdam. Most of the planning is taken care of for you; you just need to book your flights. Lodging, meeting space, agenda, and social outings will be planned and communicated well in advance.
+The entire company gathers in person twice a year. We meet-up in a different city every time. In 2022, we traveled to Miami and Amsterdam. Most of the planning is taken care of for you; you just need to book your flights. Lodging, meeting space, agenda, and social outings will be planned and communicated well in advance.
 
-In general, our meetups are largely unstructured. Every morning, we gather for breakfast at 8am. There are some scheduled talks, like the welcome session on Monday morning, lightning talks, and peer appreciation session. Occasionally, we bring in outside speakers or trainers. Other than that, the meetup is intentionally loose. Teams huddle in a breakout room, groups go out for coffee or to explore the city, or managers meet 1:1s with employees. Connection and fellowship is always the #1 goal of any meetup, which we accomplish in different ways throughout the week.
+In general, our meet-ups are largely unstructured. Every morning, we gather for breakfast at 8am. There are some scheduled talks, like the welcome session on Monday morning, lightning talks, and peer appreciation session. Occasionally, we bring in outside speakers or trainers. Other than that, the meet-up is intentionally loose. Teams huddle in a breakout room, groups go out for coffee or to explore the city, or managers meet 1:1s with employees. Connection and fellowship is always the #1 goal of any meet-up, which we accomplish in different ways throughout the week.
 
-Meetups are 1 week long. Most people arrive Sunday, we meet Monday through Thursday, and then we travel home on Friday. Everyone should come to every meetup, but skipping one here and there is okay if you have an engagement you can’t cancel.
+Meet-ups are 1 week long. Most people arrive Sunday, we meet Monday through Thursday, and then we travel home on Friday. Everyone should come to every meet-up, but skipping one here and there is okay if you have an engagement you can’t cancel.
 
-It’s important to note that meetups can be overwhelming when we’re so used to working on our own and virtually. But meetups are also rewarding and energizing, and you’ll probably find yourself looking forward to the next one within weeks of returning home.
+It’s important to note that meet-ups can be overwhelming when we’re so used to working on our own and virtually. But meet-ups are also rewarding and energizing, and you’ll probably find yourself looking forward to the next one within weeks of returning home.
 
-## Mini Meetups
+## Mini Meet-ups
 
-Once a year, you can get together with a small group of your coworkers on a mini meetup at a destination of your choosing. Mini meetups should have a work focus. They’re not meant to be social trips, and you’re not doing just your day-to-day work in the same room as your coworkers. You should be collaborating on something meaningful. It certainly doesn’t have to be big and you don’t have to produce something by the end of the meetup. Pick something you’d love to have a week to discuss in person and have fun with it.
+Once a year, you can get together with a small group of your coworkers on a mini meet-up at a destination of your choosing. Mini meet-ups should have a work focus. They’re not meant to be social trips, and you’re not doing just your day-to-day work in the same room as your coworkers. You should be collaborating on something meaningful. It certainly doesn’t have to be big and you don’t have to produce something by the end of the meet-up. Pick something you’d love to have a week to discuss in person and have fun with it.
 
-Keep in mind: your mini meetup team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meet up too. Limit yourself to 1 mini meetup per year though, whether that’s with your dedicated team or with an offshoot team.
+Keep in mind: your mini meet-up team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meet-up too. Limit yourself to 1 mini meet-up per year though, whether that’s with your dedicated team or with an offshoot team.
 
-Budget guidelines for mini meetups can be found [in Basecamp.](https://3.basecamp.com/2914079/buckets/34/messages/1400415368#__recording_1400437120)
+Budget guidelines for mini meet-ups can be found [in Basecamp.](https://3.basecamp.com/2914079/buckets/34/messages/1400415368#__recording_1400437120)
 
 ## Everyone on Support (EOS)
 

--- a/our-rituals.md
+++ b/our-rituals.md
@@ -4,19 +4,19 @@
 
 The entire company gathers in person twice a year. We meet up in a different city every time. In 2022, we traveled to Miami and Amsterdam. Most of the planning is taken care of for you; you just need to book your flights. Lodging, meeting space, agenda, and social outings will be planned and communicated well in advance.
 
-In general, our meetups are largely unstructured. Every morning, we gather for breakfast at 8am. There are some scheduled talks, like the welcome session on Monday morning, lightning talks, and peer appreciation session. Occasionally, we bring in outside speakers or trainers. Other than that, the meet-up is intentionally loose. Teams huddle in a breakout room, groups go out for coffee or to explore the city, or managers meet 1:1s with employees. Connection and fellowship is always the #1 goal of any meetup, which we accomplish in different ways throughout the week.
+In general, our meetups are largely unstructured. Every morning, we gather for breakfast at 8am. There are some scheduled talks, like the welcome session on Monday morning, lightning talks, and peer appreciation session. Occasionally, we bring in outside speakers or trainers. Other than that, the meetup is intentionally loose. Teams huddle in a breakout room, groups go out for coffee or to explore the city, or managers meet 1:1s with employees. Connection and fellowship is always the #1 goal of any meetup, which we accomplish in different ways throughout the week.
 
-Meeups are 1 week long. Most people arrive Sunday, we meet Monday through Thursday, and then we travel home on Friday. Everyone should come to every meet-up, but skipping one here and there is okay if you have an engagement you can’t cancel.
+Meetups are 1 week long. Most people arrive Sunday, we meet Monday through Thursday, and then we travel home on Friday. Everyone should come to every meetup, but skipping one here and there is okay if you have an engagement you can’t cancel.
 
-It’s important to note that meet-ups can be overwhelming when we’re so used to working on our own and virtually. But meetups are also rewarding and energizing, and you’ll probably find yourself looking forward to the next one within weeks of returning home.
+It’s important to note that meetups can be overwhelming when we’re so used to working on our own and virtually. But meetups are also rewarding and energizing, and you’ll probably find yourself looking forward to the next one within weeks of returning home.
 
 ## Mini Meetups
 
-Once a year, you can get together with a small group of your coworkers on a mini meet-up at a destination of your choosing. Mini meet-ups should have a work focus. They’re not meant to be social trips, and you’re not doing just your day-to-day work in the same room as your coworkers. You should be collaborating on something meaningful. It certainly doesn’t have to be big and you don’t have to produce something by the end of the meet-up. Pick something you’d love to have a week to discuss in person and have fun with it.
+Once a year, you can get together with a small group of your coworkers on a mini meetup at a destination of your choosing. Mini meetups should have a work focus. They’re not meant to be social trips, and you’re not doing just your day-to-day work in the same room as your coworkers. You should be collaborating on something meaningful. It certainly doesn’t have to be big and you don’t have to produce something by the end of the meetup. Pick something you’d love to have a week to discuss in person and have fun with it.
 
-Keep in mind: your mini-meet-up team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meet-up too. Limit yourself to 1 mini-meet-up per year though, whether that’s with your dedicated team or with an offshoot team.
+Keep in mind: your mini-meetup team does not have to be your formal team like Ops, Support, Mobile, etc. Colleagues who are working cross-team who have a project to get together on can meetup too. Limit yourself to 1 mini-meetup per year though, whether that’s with your dedicated team or with an offshoot team.
 
-Budget guidelines for mini meet-ups can be found [in Basecamp.](https://3.basecamp.com/2914079/buckets/34/messages/1400415368#__recording_1400437120)
+Budget guidelines for mini meetups can be found [in Basecamp.](https://3.basecamp.com/2914079/buckets/34/messages/1400415368#__recording_1400437120)
 
 ## Everyone on Support (EOS)
 


### PR DESCRIPTION
I first noticed a `meeups` typo here, but after further review, there are two different spellings used for the noun "meetup":
1. `meetup`
2. `meet-up`

Since the headings favor "meetup" I'm proposing to align on that everywhere.