### PR TITLE
fix visa checker URL as the redirection to the new domain does not work

### DIFF
--- a/international-travel-guide.md
+++ b/international-travel-guide.md
@@ -34,7 +34,7 @@ Citizens of some countries are eligible for [Global Entry](https://www.cbp.gov/t
 
 The visa requirements for your nationality will vary depending on the country you plan to visit, as individual visa policies and requirements vary for different foreign citizens. It may or may not be necessary to obtain a travel document to visit your country of destination.
 
-Please check the requirements for your nationality with your destination country as far in advance of travel as you can. You can also use a [visa checker](https://www.onlinevisa.com/visa-requirements/). You may be able to travel visa-free, or you may need to obtain a visa, a waiver, or an electronic travel authorization.
+Please check the requirements for your nationality with your destination country as far in advance of travel as you can. You can also use a [visa checker](https://www.handyvisas.com/visa-requirements/). You may be able to travel visa-free, or you may need to obtain a visa, a waiver, or an electronic travel authorization.
 
 ### Invitation Letter
 


### PR DESCRIPTION
According to the [Wayback Machine](https://web.archive.org/web/20221001000000*/https://www.onlinevisa.com/visa-requirements), it seems like `onlinevisa.com` rebranded to `handyvisas.com` between the end of 2022 and beginning of 2023. Some redirections do work, this one doesn't so I replaced the link.