### PR TITLE
Update handbook with usage of Linux and Omarchy

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -10,7 +10,7 @@ A day or two before you start, your manager will email you instructions for your
 
 On your first day, you’ll log into Basecamp to see a project dedicated to your onboarding called “Welcome, [your name]!”. Your welcome project will contain a few to-do lists, tailored to your role and linking to accounts or services that you need to set up. You’ll also see to-do lists that your Ops buddy and manager will be working through. Your Ops buddy and your manager will be in contact with you as you set up your environment, should you have questions or get stuck.
 
-To keep everyone's devices safe and secure, we manage all our Mac devices using [Kandji](https://kandji.io) as well as our in-house tool [Shipshape 🔒](https://github.com/basecamp/shipshape/).
+To keep everyone's devices safe and secure, we manage all our laptops according to [managing work devices](https://github.com/basecamp/handbook/blob/master/managing-work-devices.md).
 
 Your training schedules and [onboarding expectations](https://github.com/basecamp/handbook/blob/master/making-a-career.md#your-first-90-days) will be in your welcome project. You’ll also find docs with helpful links to technical documentation, walkthrough videos, important Basecamp projects, and more.
 

--- a/managing-work-devices.md
+++ b/managing-work-devices.md
@@ -1,6 +1,16 @@
 # Managing work devices
 
-Everyone receives a new Mac [when they join 37signals](https://github.com/basecamp/handbook/blob/f094e5f8b778515d363d84c9ae139cc006b66f3b/getting-started.md#your-first-few-days). We centrally manage and secure these devices with [Kandji](https://kandji.io/) which reduces our exposure to security incidents. Kandji applies a standard configuration to every device (e.g. enable disk encryption, firewall, password rules), it installs essential apps (e.g. EncryptMe), and it will ensure the apps have the latest security updates applied. Kandji also allows us to remotely wipe devices should they be lost, or when an employee leaves the company.
+Everyone receives a new laptop (Linux (default)[1], Mac or Windows depending on role and needs) [when they join 37signals](https://github.com/basecamp/handbook/blob/master/getting-started.md#your-first-few-days). 
+
+## Linux
+
+Default laptop option for the majority of employees and roles, currently unmanaged but expected to change soon.
+
+The distro is Omarchy (O-march-ee), an opinionated Arch flavor.
+
+## Mac
+
+Macs are centrally managed and secured with [Kandji](https://kandji.io/) which reduces our exposure to security incidents. Kandji applies a standard configuration to every device (e.g. enable disk encryption, firewall, password rules), it installs essential apps (e.g. EncryptMe), and it will ensure the apps have the latest security updates applied. Kandji also allows us to remotely wipe devices should they be lost, or when an employee leaves the company.
 
 This doesn’t mean you are being monitored or tracked! Kandji is a configuration management system, not a panopticon.
 
@@ -10,10 +20,12 @@ Knowing our devices are safe and secure allows us to entrust our work computers 
 
 Please do not keep any personal data on your 37signals-issued laptop. You should maintain a separate, personally-owned machine if you need a home computer. The company reserves the right to and may be required to confiscate your laptop or its data at any point.
 
-## Mobile devices, Windows and Linux
+## Mobile devices, Windows
 
-Devices running Android, iOS/iPadOS, Windows or Linux are currently unmanaged. It’s fine to install our BC4 and HEY apps on these devices to access work projects and email, but since they’re unmanaged – and therefore ‘untrusted’ – it’s not okay to store 37signals code or secrets on them. If you're coding or accessing secure systems, you should be doing so on a Kandji-managed Mac.
+Devices running Android, iOS/iPadOS or Windows are currently unmanaged. It’s fine to install our BC4 and HEY apps on these devices to access work projects and email, but since they’re unmanaged – and therefore ‘untrusted’ – it’s not okay to store 37signals code or secrets on them. If you're coding or accessing secure systems, you should be doing so on a company-managed laptop.
 
 ## FAQ
 
 There are many questions that arise from IT policies such as this, so we've written [an FAQ in BC4](https://3.basecamp.com/2914079/buckets/31986799/documents/6044843594) to help answer them.
+
+[1]: If you are a developer and want a Mac, without a clear demand for your role, you'll have to beat David on Circuit de la Sarthe (aka Le Mans) in a racing simulator. One lap, flying start, with steering wheel and manual shift and car of your choice.

--- a/our-internal-systems.md
+++ b/our-internal-systems.md
@@ -30,7 +30,7 @@ We track programming exceptions on Sentry. When a customer hits a “Oops, somet
 
 ## Kandji
 
-[Kandji](https://kandji.io) is how we make sure all work laptops are securely configured and running the latest software updates. It helps us reduce our exposure to security incidents. You can read more about this in [Managing work devices](https://github.com/basecamp/handbook/blob/master/managing-work-devices.md).
+[Kandji](https://kandji.io) is how we make sure all Mac laptops are securely configured and running the latest software updates. It helps us reduce our exposure to security incidents. You can read more about this in [Managing work devices](https://github.com/basecamp/handbook/blob/master/managing-work-devices.md).
 
 ## Shipshape
 


### PR DESCRIPTION
As 37signals has adopted a new default hardware and software stack for developers, an update to the handbook is needed.

Developers now defaults to a Linux Framwork computer running Omarchy.